### PR TITLE
improve sample-code to popp api spec compatibility

### DIFF
--- a/popp-commons/src/main/java/de/gematik/poppcommons/api/messages/ScenarioResponseMessage.java
+++ b/popp-commons/src/main/java/de/gematik/poppcommons/api/messages/ScenarioResponseMessage.java
@@ -53,7 +53,7 @@ public final class ScenarioResponseMessage extends PoPPMessage implements Serial
    * Scenario does not contain any command APDU. Response from the smartcard encoded in hexadecimal
    * characters [0-9a-f]. Contains at least 4 characters (status word).
    */
-  @JsonProperty("responses")
+  @JsonProperty("steps")
   @NonNull
   private List<String> steps;
 


### PR DESCRIPTION
The https://github.com/gematik/api-popp/blob/main/src/openapi/I_PoPP_Token_Generation.yaml defines that ScenarioResponseMessage field should be named steps and not responses => Rename in the sample code.